### PR TITLE
libnuma-dev was missing as a prerequisite for dpdk

### DIFF
--- a/ubuntu_install.md
+++ b/ubuntu_install.md
@@ -19,6 +19,7 @@ Here are the installations steps for Ubuntu 16.04.
 	apt install subversion
 	apt install rpm
 	apt install libreadline6 libreadline6-dev
+	apt install libnuma-dev
 
 ## Install libcap
 


### PR DESCRIPTION
Hello Alex,
seems like on multi-socket configurations, dpdk needs this package on Ubuntu.

kr,
Tibor